### PR TITLE
Add CRA Brief Guide for OSS Developers link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ This is a list of materials (documents, services, and so on) released by the
 
 - [OpenSSF CRA Blog and Resources](https://openssf.org/public-policy/eu-cyber-resilience-act/)
 - [CRA Documents](/CRA)
+- [CRA Brief Guide for OSS Developers](https://best.openssf.org/CRA-Brief-Guide-for-OSS-Developers)
 
 ## Contributing
 


### PR DESCRIPTION
Feels like the brief guide should be available at the top level of this page?